### PR TITLE
FF6 Compatibility

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -6,7 +6,7 @@
   <RDF:Description RDF:about="rdf:#$Yrk2H"
                    em:id="{ec8030f7-c20a-464f-9b0e-13a3a9e97384}"
                    em:minVersion="3.0"
-                   em:maxVersion="4.0" />
+                   em:maxVersion="6.0" />
   <RDF:Description RDF:about="urn:mozilla:install-manifest"
                    em:id="scrollsearchengines@einaregilsson.com"
                    em:name="Scroll Search Engines"

--- a/make.sh
+++ b/make.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Linux shell build script for extension
+#
+# Assumes to be in the right directory
+
+EXT=ScrollSearchEngines.xpi
+BUILD="build"
+TARGET="$BUILD/$EXT"
+
+
+if [ ! -d $BUILD ]; then
+  mkdir $BUILD
+fi
+if [ -d $TARGET ]; then
+  rm -vf $TARGET
+fi
+zip -r $TARGET * -x build* *.py *.bat *.sh


### PR DESCRIPTION
This plugin is great, but it can't be installed on FF6 only because the max_version state that FF4 is the last one. 
Here is the only change required.

Tested it under Archlinux + FF6. It works.

Btw, I added a make.sh in order to be able to easily build the xpi under Linux.

Hopes it will be uprgraded soon.
